### PR TITLE
Fix build errors for Mac Catalyst

### DIFF
--- a/ShralpTide.xcworkspace/contents.xcworkspacedata
+++ b/ShralpTide.xcworkspace/contents.xcworkspacedata
@@ -2,7 +2,7 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:/Users/mparlee/Development/swift/ShralpTideWorkspace/ShralpTide/ShralpTide.xcodeproj">
+      location = "group:ShralpTide/ShralpTide.xcodeproj">
    </FileRef>
    <FileRef
       location = "group:ShralpTideFramework/ShralpTideFramework.xcodeproj">

--- a/ShralpTide/Shared/Components/ContentView/PadTidesView.swift
+++ b/ShralpTide/Shared/Components/ContentView/PadTidesView.swift
@@ -57,7 +57,7 @@ struct PadTidesView: View {
                             .padding(.top)
                             .padding(.leading)
                             .padding(.trailing)
-                        if let tideData = appState.tidesForDays[pageIndex] {
+                        if let tideData = appState.tidesForDays[safe: pageIndex] {
                           Text(tideData.startTime != nil ? nonMutatingFormatter().string(from: tideData.startTime) : "")
                             .font(.title)
                             .lineLimit(1)

--- a/ShralpTide/Shared/Extensions/Collection.swift
+++ b/ShralpTide/Shared/Extensions/Collection.swift
@@ -1,0 +1,15 @@
+//
+//  Collection.swift
+//  ShralpTide
+//
+//  Created by Jake Teton-Landis on 11/23/23.
+//
+
+import Foundation
+
+extension Collection {
+    /// Returns the element at the specified index if it is within bounds, otherwise nil.
+    subscript (safe index: Index) -> Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
+}

--- a/ShralpTide/ShralpTide.xcodeproj/project.pbxproj
+++ b/ShralpTide/ShralpTide.xcodeproj/project.pbxproj
@@ -894,8 +894,9 @@
 		DC26BAE324BB807900453A5F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1250;
-				LastUpgradeCheck = 1400;
+				LastUpgradeCheck = 1500;
 				TargetAttributes = {
 					DC25E6BB2636870800D214D0 = {
 						CreatedOnToolsVersion = 12.4;
@@ -1321,6 +1322,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				EXCLUDED_ARCHS = "";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -1388,6 +1390,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				EXCLUDED_ARCHS = "";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;

--- a/ShralpTide/ShralpTide.xcodeproj/project.pbxproj
+++ b/ShralpTide/ShralpTide.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C1E8CCCE2B10309800393AA8 /* Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E8CCCD2B10309800393AA8 /* Collection.swift */; };
 		DC079F74259BAED800F1CB0E /* InteractiveChartViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC079F73259BAED800F1CB0E /* InteractiveChartViewModifier.swift */; };
 		DC079F80259C34BB00F1CB0E /* LabeledChartViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC079F7F259C34BB00F1CB0E /* LabeledChartViewModifier.swift */; };
 		DC0DE589258C1B6C00FD75A0 /* EnvironmentValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0DE588258C1B6C00FD75A0 /* EnvironmentValues.swift */; };
@@ -250,6 +251,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		C1E8CCCD2B10309800393AA8 /* Collection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Collection.swift; sourceTree = "<group>"; };
 		DC079F73259BAED800F1CB0E /* InteractiveChartViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractiveChartViewModifier.swift; sourceTree = "<group>"; };
 		DC079F7F259C34BB00F1CB0E /* LabeledChartViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabeledChartViewModifier.swift; sourceTree = "<group>"; };
 		DC0DE588258C1B6C00FD75A0 /* EnvironmentValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentValues.swift; sourceTree = "<group>"; };
@@ -681,6 +683,7 @@
 		DC3B36B7263BB87800DA83E1 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				C1E8CCCD2B10309800393AA8 /* Collection.swift */,
 				DC3B36B8263BB87800DA83E1 /* Date.swift */,
 				DC3B36B9263BB87800DA83E1 /* SDTide.swift */,
 				DC3B36BA263BB87800DA83E1 /* SDTideStation.swift */,
@@ -1078,6 +1081,7 @@
 				DC115D9725A28D6A00954972 /* PagerView.swift in Sources */,
 				DC115DDB25ABDA7000954972 /* ChartUtils.swift in Sources */,
 				DC115DEA25AD576100954972 /* FavoriteRow.swift in Sources */,
+				C1E8CCCE2B10309800393AA8 /* Collection.swift in Sources */,
 				DC0DE7AF259305F600FD75A0 /* AppState.swift in Sources */,
 				DC43CBF725C78697002A330E /* Region.swift in Sources */,
 				DC77459E24F31681001747AE /* TideEventsPageView.swift in Sources */,

--- a/ShralpTide/ShralpTide.xcodeproj/xcshareddata/xcschemes/LocationIntentsExtension.xcscheme
+++ b/ShralpTide/ShralpTide.xcodeproj/xcshareddata/xcschemes/LocationIntentsExtension.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1500"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/ShralpTide/ShralpTide.xcodeproj/xcshareddata/xcschemes/ShralpTide2.xcscheme
+++ b/ShralpTide/ShralpTide.xcodeproj/xcshareddata/xcschemes/ShralpTide2.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1500"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ShralpTide/ShralpTide.xcodeproj/xcshareddata/xcschemes/TideWidgetExtension.xcscheme
+++ b/ShralpTide/ShralpTide.xcodeproj/xcshareddata/xcschemes/TideWidgetExtension.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1500"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/ShralpTide/ShralpTide.xcodeproj/xcshareddata/xcschemes/WatchTides (Complication).xcscheme
+++ b/ShralpTide/ShralpTide.xcodeproj/xcshareddata/xcschemes/WatchTides (Complication).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1500"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ShralpTide/ShralpTide.xcodeproj/xcshareddata/xcschemes/WatchTides.xcscheme
+++ b/ShralpTide/ShralpTide.xcodeproj/xcshareddata/xcschemes/WatchTides.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1500"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ShralpTideFramework/ShralpTideFramework.xcodeproj/project.pbxproj
+++ b/ShralpTideFramework/ShralpTideFramework.xcodeproj/project.pbxproj
@@ -966,7 +966,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.shralpsoftware.ShralpTideFramework;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MACCATALYST = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -994,7 +994,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.shralpsoftware.ShralpTideFramework;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MACCATALYST = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;


### PR DESCRIPTION
Happy Thanksgiving!

This PR fixes build issues that prevented me from running a Mac Catalyst version of the iPad app:

- Fix a hard-coded path to use a relative path instead.
- Apply the Xcode 15 update suggestions to the project, this seemed innocuous, and didn't introduce any new errors.
- Fix a Swift build error from `if let x = array[y]`; this isn't optional and will throw if out of bounds. I added a "safe" subscript operator extension that returns an option.
- Enable Mac Catalyst support in TideFramework.

After these changes, ShrapleTide2 builds and runs just fine on my Mac 🎉 

<img width="982" alt="image" src="https://github.com/shralpmeister/shralptide2/assets/296279/91a17577-6bd6-4e9b-9bcc-faba9b0c33a7">
